### PR TITLE
Add mcounteren support and reorder some Performance_Monitor things with comments

### DIFF
--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -181,7 +181,7 @@ typedef struct {
    Bool evt_1_BUSY_NO_CONSUME;
    Bool evt_2_BUSY_NO_CONSUME;
    Bool evt_3_BUSY_NO_CONSUME;
-   Bool evt_IMPRECISE_SETBOUND;
+   Bool evt_IMPRECISE_SETBOUNDS;
    Bool evt_UNREPRESENTABLE_CAP;
    Bool evt_MEM_CAP_LOAD;
    Bool evt_MEM_CAP_STORE;
@@ -996,7 +996,7 @@ module mkCPU (CPU_IFC);
 		     CapMem capMem = cast (capReg);
 		     events.evt_MEM_CAP_STORE_TAG_SET = isValidCap (capMem);
 		  end
-		  events.evt_IMPRECISE_SETBOUND =  ! stage1.out.data_to_stage2.check_exact_success;
+		  events.evt_IMPRECISE_SETBOUNDS = ! stage1.out.data_to_stage2.check_exact_success;
 		  events.evt_UNREPRESENTABLE_CAP = ! stage1.out.data_to_stage2.set_offset_in_bounds;
 `endif
 	       end
@@ -1265,9 +1265,15 @@ module mkCPU (CPU_IFC);
    Vector #(16, Bit #(Counter_Width)) dmem_evts_vec = to_large_vector (near_mem.dmem.events);
    Vector #(32, Bit #(Counter_Width)) external_evts_vec = to_large_vector (w_external_evts);
 
+   // Events are ordered here:
+   // 0x00: Null event
+   // 0x01 - 1f: Core events
    let events = append (null_evt, core_evts_vec);
+   // 0x20 - 2f: IMem events
    events = append (events, imem_evts_vec);
+   // 0x30 - 3f: DMem events
    events = append (events, dmem_evts_vec);
+   // 0x40 - 6f: External events
    events = append (events, external_evts_vec);
 
    (* fire_when_enabled, no_implicit_conditions *)

--- a/src_Core/Core/Core.bsv
+++ b/src_Core/Core/Core.bsv
@@ -139,6 +139,7 @@ module mkCore (Core_IFC #(N_External_Interrupt_Sources));
 `ifdef PERFORMANCE_MONITORING
    let axi4_mem_shim_slave_monitor <- monitorAXI4_Slave (axi4_mem_shim_slave);
    axi4_mem_shim_slave = axi4_mem_shim_slave_monitor.ifc;
+   let slave_events = to_vector (axi4_mem_shim_slave_monitor.events);
 `ifdef ISA_CHERI
 `ifndef NO_TAG_CACHE
    let axi4_mem_shim_master_monitor <- monitorAXI4_Master (axi4_mem_shim_master);
@@ -451,8 +452,10 @@ module mkCore (Core_IFC #(N_External_Interrupt_Sources));
 
 `ifdef PERFORMANCE_MONITORING
    rule rl_relay_external_events;
-      let slave_events = to_vector (axi4_mem_shim_slave_monitor.events);
-      let events = append (tag_cache_evts, append (slave_events, tag_cache_master_evts));
+      // External events are ordered here:
+      let events = slave_events;
+      events = append (tag_cache_master_evts, events);
+      events = append (tag_cache_evts, events);
       cpu.relay_external_events (to_large_vector (events));
    endrule
 `endif

--- a/src_Core/ISA/ISA_Decls_Priv_M.bsv
+++ b/src_Core/ISA/ISA_Decls_Priv_M.bsv
@@ -482,24 +482,41 @@ typedef struct {
    Bit#(1) ir;
    Bit#(1) tm;
    Bit#(1) cy;
+`ifdef PERFORMANCE_MONITORING
+   Bit#(29) ctr;
+`endif
 } MCounteren
 deriving (Bits, FShow);
 
 function WordXL mcounteren_to_word (MCounteren mc);
    return {0,
+`ifdef PERFORMANCE_MONITORING
+           mc.ctr,
+`endif
            mc.ir,
 	   mc.tm,
 	   mc.cy};
 endfunction
 
 function MCounteren word_to_mcounteren (WordXL x);
-   return MCounteren {ir: x[2],
-                      tm: x[1],
+`ifdef PERFORMANCE_MONITORING
+   Bit#(No_Of_Ctrs) ctrs = x[valueOf (No_Of_Ctrs)+2:3];
+`endif
+   return MCounteren {
+`ifdef PERFORMANCE_MONITORING
+		      ctr: {0, ctrs},
+`endif
+		      ir: x[2],
+		      tm: x[1],
 		      cy: x[0]};
 endfunction
 
 function MCounteren mcounteren_reset_value;
-   return MCounteren {ir: 1'b0,
+   return MCounteren {
+`ifdef PERFORMANCE_MONITORING
+                      ctr: 29'b0,
+`endif
+                      ir: 1'b0,
                       tm: 1'b0,
 		      cy: 1'b0};
 endfunction
@@ -738,6 +755,8 @@ endfunction
 // ================================================================
 // The width of individual counters
 
+`ifdef PERFORMANCE_MONITORING
+
 `ifndef COUNTER_WIDTH
 `define COUNTER_WIDTH 64
 `endif
@@ -752,5 +771,7 @@ typedef `NO_OF_CTRS No_Of_Ctrs;
 `define NO_OF_EVTS 96
 `endif
 typedef `NO_OF_EVTS No_Of_Evts;
+
+`endif
 
 // ================================================================

--- a/src_Core/RegFiles/CSR_RegFile_MSU.bsv
+++ b/src_Core/RegFiles/CSR_RegFile_MSU.bsv
@@ -489,7 +489,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    Word ctr_inhibit = zeroExtend ({ perf_counters.read_ctr_inhibit, ctr_inhibit_lsb });
    CSR_Addr no_of_ctrs = fromInteger (valueOf (No_Of_Ctrs));
 `else
-   Vector #(0, ReadOnly #(Bit #(Counter_Width))) ctrs = newVector;
+   Vector #(0, ReadOnly #(Bit #(64))) ctrs = newVector;
    Vector #(0, ReadOnly #(Word)) ctr_sels = newVector;
    Word ctr_inhibit = 0;
    CSR_Addr no_of_ctrs = 0;
@@ -1842,9 +1842,16 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	      && (   ((csr_addr == csr_addr_cycle)   && (rg_mcounteren.cy == 0))
 		  || ((csr_addr == csr_addr_time)    && (rg_mcounteren.tm == 0))
 		  || ((csr_addr == csr_addr_instret) && (rg_mcounteren.ir == 0))
+`ifndef PERFORMANCE_MONITORING
 		  || ((csr_addr_hpmcounter3  <= csr_addr) && (csr_addr <= csr_addr_hpmcounter31))
 `ifdef RV32
 		  || ((csr_addr_hpmcounter3h <= csr_addr) && (csr_addr <= csr_addr_hpmcounter31h))
+`endif
+`else // PERFORMANCE_MONITORING
+		  || ((csr_addr_hpmcounter3  <= csr_addr) && (csr_addr <= csr_addr_hpmcounter31) && (rg_mcounteren.ctr[csr_addr - csr_addr_hpmcounter3] == 0))
+`ifdef RV32
+		  || ((csr_addr_hpmcounter3h <= csr_addr) && (csr_addr <= csr_addr_hpmcounter31h) && (rg_mcounteren.ctr[csr_addr - csr_addr_hpmcounter3h] == 0))
+`endif
 `endif
 		  ));
    endmethod


### PR DESCRIPTION
Flute already seems to have support for `mcounteren` with ir, tm and cy. This should add it for the other 29 counters. However the `csr_counter_read_fault` method doesn't seem to be checked anywhere anyway...