### PR TITLE
Update CSR/SCR register file to use a BRAM

### DIFF
--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -273,6 +273,7 @@ module mkCPU (CPU_IFC);
    // These regs save info on a trap in Stage1 or Stage2
    Reg #(Trap_Info_Pipe) rg_trap_info       <- mkRegU;
    Reg #(Bool)       rg_trap_interrupt  <- mkRegU;
+   Reg #(CSR_SCR_Address) rg_csr_scr_address <- mkRegU;
    Reg #(Instr)      rg_trap_instr      <- mkRegU;
 `ifdef INCLUDE_TANDEM_VERIF
    Reg #(Trace_Data) rg_trap_trace_data <- mkRegU;
@@ -1086,6 +1087,7 @@ module mkCPU (CPU_IFC);
       rg_trap_info       <= stage2.out.trap_info;
       rg_trap_interrupt  <= False;
       rg_trap_instr      <= stage2.out.data_to_stage3.instr;
+      rg_csr_scr_address <= instr_csr_scr_addr (stage2.out.data_to_stage3.instr);
 `ifdef RVFI_DII
       rg_next_seq        <= stage2.out.data_to_stage3.instr_seq + 1;
 `endif
@@ -1123,6 +1125,7 @@ module mkCPU (CPU_IFC);
       rg_trap_info       <= stage1.out.trap_info;
       rg_trap_interrupt  <= False;
       rg_trap_instr      <= stage1.out.data_to_stage2.instr;
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
 `ifdef RVFI_DII
       rg_next_seq        <= stage1.out.data_to_stage2.instr_seq + 1;
 `endif
@@ -1152,6 +1155,9 @@ module mkCPU (CPU_IFC);
       let exc_code     = rg_trap_info.exc_code;
       let tval         = rg_trap_info.tval;
       let instr        = rg_trap_instr;
+
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
+      csr_regfile.read_req (instr_csr_scr_addr (stage1.out.data_to_stage2.instr));
       let is_interrupt = rg_trap_interrupt;
 
       // Take trap, save trap information for next phase
@@ -1308,6 +1314,9 @@ module mkCPU (CPU_IFC);
                                       tval:     stage1.out.trap_info.tval};
       rg_trap_interrupt <= False;
       rg_trap_instr     <= stage1.out.data_to_stage2.instr;    // Also used in successful CSSRW
+
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
+      csr_regfile.read_req (instr_csr_scr_addr (stage1.out.data_to_stage2.instr));
 `ifdef INCLUDE_TANDEM_VERIF
       rg_trap_trace_data <= stage1.out.data_to_stage2.trace_data;
 `elsif RVFI
@@ -1323,6 +1332,7 @@ module mkCPU (CPU_IFC);
 
       let instr    = rg_trap_instr;
       let scr_addr = instr_rs2    (instr);
+      let scr_address = rg_csr_scr_address;
       let rs1      = instr_rs1    (instr);
       let rd       = instr_rd     (instr);
 
@@ -1354,19 +1364,25 @@ module mkCPU (CPU_IFC);
       end
       else begin
 	 // Read the SCR only if Rd is not 0
-	 CapReg scr_val = ?;
+	 CapPipe scr_val = ?;
          if (scr_addr == scr_addr_DDC) begin
             scr_val = cast(rg_ddc);
          end else
 	 if (rd != 0) begin
-	    let m_scr_val = csr_regfile.read_scr (scr_addr);
-	    scr_val   = fromMaybe (?, m_scr_val);
+	    //let m_scr_val = csr_regfile.read_scr (scr_addr);
+	    //let m_scr_val = csr_regfile.read_scr (scr_address);
+	    //scr_val   = fromMaybe (?, m_scr_val);
+	    scr_val = cast (csr_regfile.read_rsp);
+            if (cur_verbosity > 1) begin
+               $display ("would have requested address: ", fshow (scr_addr));
+               $display ("reading csr regfile (scr) returned ", fshow (scr_val));
+            end
 	 end
 
 	 // Writeback to GPR file
 	 let new_rd_val = scr_val;
 
-	 gpr_regfile.write_rd (rd, new_rd_val);
+	 gpr_regfile.write_rd (rd, cast (new_rd_val));
 
    CapPipe new_scr_val_unpacked = cast(scr_val);
 
@@ -1375,8 +1391,11 @@ module mkCPU (CPU_IFC);
          rg_ddc <= stage2_val1;
    end else
    if (rs1 != 0) begin
-	    let new_scr_val <- csr_regfile.mav_scr_write (scr_addr, cast(stage2_val1));
-      new_scr_val_unpacked = cast(new_scr_val);
+	    //let new_scr_val <- csr_regfile.mav_scr_write (scr_addr, cast(stage2_val1));
+	    //let new_scr_val <- csr_regfile.mav_scr_write (scr_address, cast(stage2_val1));
+	    //let new_scr_val <- csr_regfile.mav_scr_write (scr_address, cast(stage2_val1));
+            //new_scr_val_unpacked = cast(new_scr_val);
+	    new_scr_val_unpacked <- csr_regfile.write_req (scr_address, cast(stage2_val1));
    end
 
 	 // Accounting
@@ -1455,6 +1474,9 @@ module mkCPU (CPU_IFC);
                                       tval:     stage1.out.trap_info.tval};
       rg_trap_interrupt <= False;
       rg_trap_instr     <= stage1.out.data_to_stage2.instr;    // Also used in successful CSSRW
+
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
+      csr_regfile.read_req (instr_csr_scr_addr (stage1.out.data_to_stage2.instr));
 `ifdef INCLUDE_TANDEM_VERIF
       rg_trap_trace_data <= stage1.out.data_to_stage2.trace_data;
 `elsif RVFI
@@ -1507,8 +1529,13 @@ module mkCPU (CPU_IFC);
 	 if (rd != 0) begin
 	    begin
 	       // Note: csr_regfile.read should become ActionValue if it acquires side effects
-	       let m_csr_val = csr_regfile.read_csr (csr_addr);
-	       csr_val   = fromMaybe (?, m_csr_val);
+	       //let m_csr_val = csr_regfile.read_csr (csr_addr);
+	       //csr_val   = fromMaybe (?, m_csr_val);
+	       csr_val = getAddr (csr_regfile.read_rsp);
+               if (cur_verbosity > 1) begin
+                  $display ("would have requested address: ", fshow (csr_addr));
+                  $display ("reading csr regfile (csr) returned ", fshow (csr_val));
+               end
 	    end
 	 end
 
@@ -1522,9 +1549,10 @@ module mkCPU (CPU_IFC);
 `endif
 
 	 // Writeback to CSR file
-	 let csr_write_result <- csr_regfile.mav_csr_write (csr_addr, rs1_val);
-	 let new_csr_val       = csr_write_result.new_csr_value;
-	 let m_new_mstatus     = csr_write_result.m_new_csr_value2;
+	 //let csr_write_result <- csr_regfile.mav_csr_write (csr_addr, rs1_val);
+	 //let new_csr_val       = csr_write_result.new_csr_value;
+	 //let m_new_mstatus     = csr_write_result.m_new_csr_value2;
+	 let new_csr_val <- csr_regfile.write_req (rg_csr_scr_address, nullWithAddr (rs1_val));
 
 	 // Accounting
 	 csr_regfile.csr_minstret_incr;
@@ -1598,6 +1626,9 @@ module mkCPU (CPU_IFC);
                                       tval:     stage1.out.trap_info.tval};
       rg_trap_interrupt <= False;
       rg_trap_instr     <= stage1.out.data_to_stage2.instr;    // TODO: this is also used for successful CSRRW
+
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
+      csr_regfile.read_req (instr_csr_scr_addr (stage1.out.data_to_stage2.instr));
 `ifdef INCLUDE_TANDEM_VERIF
       rg_trap_trace_data <= stage1.out.data_to_stage2.trace_data;    // TODO: this is also used for successful CSRRW
 `elsif RVFI
@@ -1649,8 +1680,13 @@ module mkCPU (CPU_IFC);
 	 WordXL csr_val = ?;
 	 begin
 	    // Note: csr_regfile.read should become ActionValue if it acquires side effects
-	    let m_csr_val  = csr_regfile.read_csr (csr_addr);
-	    csr_val = fromMaybe (?, m_csr_val);
+	    //let m_csr_val  = csr_regfile.read_csr (csr_addr);
+	    //csr_val = fromMaybe (?, m_csr_val);
+	    csr_val = getAddr (csr_regfile.read_rsp);
+            if (cur_verbosity > 1) begin
+               $display ("would have requested address: ", fshow (csr_addr));
+               $display ("reading csr regfile (csr) returned ", fshow (csr_val));
+            end
 	 end
 
 	 // Writeback to GPR file
@@ -2231,6 +2267,7 @@ module mkCPU (CPU_IFC);
 				       tval:     0};
       rg_trap_interrupt  <= True;
       rg_trap_instr      <= stage1.out.data_to_stage2.instr;
+      rg_csr_scr_address <= instr_csr_scr_addr (stage1.out.data_to_stage2.instr);
 
 `ifdef INCLUDE_TANDEM_VERIF
       // rg_trap_trace_data <= ?;    // Will be filled in in rl_trap

--- a/src_Core/ISA/ISA_Decls.bsv
+++ b/src_Core/ISA/ISA_Decls.bsv
@@ -201,7 +201,8 @@ function CSR_SCR_Address instr_csr_scr_addr (Instr x);
       // SCR address is stored in RS2
       return fn_scr_addr_to_regname (instr_rs2 (x));
    end else begin
-      return SCR_Address (scr_addr_MTCC);
+      // placeholder
+      return RegFile_Index (CSR_DSCRATCH0);
    end
 endfunction
 
@@ -243,7 +244,6 @@ typedef struct {
    RegName   rs2;
    RegName   rs3;
    CSR_Addr  csr;
-   //CSR_Addr  csr;
    CSR_SCR_Address csr_scr_addr;
 
    Bit #(3)  funct3;
@@ -276,8 +276,6 @@ function Decoded_Instr fv_decode (Instr instr);
 			 rs1:       instr_rs1      (instr),
 			 rs2:       instr_rs2      (instr),
 			 rs3:       instr_rs3      (instr),
-			 //csr:       instr_csr      (instr),
-                         csr_scr_addr: instr_csr_scr_addr (instr),
 
 			 funct3:    instr_funct3   (instr),
 			 funct5:    instr_funct5   (instr),
@@ -1101,10 +1099,21 @@ typedef union tagged {
 
 function CSR_SCR_Address fn_csr_addr_to_regname (CSR_Addr addr);
    case (addr)
+      // machine mode
       csr_addr_mscratch:   return RegFile_Index (CSR_MSCRATCH);
+      csr_addr_mtvec:      return RegFile_Index (SCR_MTCC);
+      csr_addr_mepc:       return RegFile_Index (SCR_MEPCC);
+      // supervisor mode
+      csr_addr_stvec:      return RegFile_Index (SCR_STCC);
+      csr_addr_sepc:       return RegFile_Index (SCR_SEPCC);
       csr_addr_sscratch:   return RegFile_Index (CSR_MSCRATCH);
+      // debug
       csr_addr_dscratch0:  return RegFile_Index (CSR_DSCRATCH0);
       csr_addr_dscratch1:  return RegFile_Index (CSR_DSCRATCH1);
+      csr_addr_tselect:    return RegFile_Index (CSR_TSELECT);
+      csr_addr_tdata1:     return RegFile_Index (CSR_TDATA1);
+      csr_addr_tdata2:     return RegFile_Index (CSR_TDATA2);
+      csr_addr_tdata3:     return RegFile_Index (CSR_TDATA3);
       default:             return CSR_Address (addr);
    endcase
 endfunction
@@ -1112,16 +1121,18 @@ endfunction
 function CSR_SCR_Address fn_scr_addr_to_regname (SCR_Addr addr);
    case (addr)
       scr_addr_MTDC:       return RegFile_Index (SCR_MTDC);
-      scr_addr_MScratchC:  return RegFile_Index (SCR_SSCRATCHC);
+      scr_addr_MTCC:       return RegFile_Index (SCR_MTCC);
+      scr_addr_MScratchC:  return RegFile_Index (SCR_MSCRATCHC);
+      scr_addr_MEPCC:      return RegFile_Index (SCR_MEPCC);
 
       scr_addr_STDC:       return RegFile_Index (SCR_STDC);
+      scr_addr_STCC:       return RegFile_Index (SCR_STCC);
       scr_addr_SScratchC:  return RegFile_Index (SCR_SSCRATCHC);
+      scr_addr_SEPCC:      return RegFile_Index (SCR_SEPCC);
 
       default:             return SCR_Address (addr);
    endcase
 endfunction
-
-
 
 // ----------------
 // User-level CSR addresses

--- a/src_Core/ISA/ISA_Decls.bsv
+++ b/src_Core/ISA/ISA_Decls.bsv
@@ -48,7 +48,8 @@ import CHERICC_Fat  :: *;
 // ================================================================
 // BSV project imports
 
-// None
+// TODO include this rather than importing it?
+import ISA_Decls_CSR :: *;
 
 // ================================================================
 
@@ -192,6 +193,18 @@ function  RegName    instr_rs2      (Instr x); return x [24:20]; endfunction
 function  RegName    instr_rs3      (Instr x); return x [31:27]; endfunction
 function  CSR_Addr   instr_csr      (Instr x); return unpack(x [31:20]); endfunction
 
+function CSR_SCR_Address instr_csr_scr_addr (Instr x);
+   let opcode = instr_opcode (x);
+   if (opcode == op_SYSTEM) begin
+      return fn_csr_addr_to_regname (instr_csr (x));
+   end else if (opcode == op_cap_Manip) begin
+      // SCR address is stored in RS2
+      return fn_scr_addr_to_regname (instr_rs2 (x));
+   end else begin
+      return SCR_Address (scr_addr_MTCC);
+   end
+endfunction
+
 function  Bit #(12)  instr_I_imm12  (Instr x);
    return x [31:20];
 endfunction
@@ -230,6 +243,8 @@ typedef struct {
    RegName   rs2;
    RegName   rs3;
    CSR_Addr  csr;
+   //CSR_Addr  csr;
+   CSR_SCR_Address csr_scr_addr;
 
    Bit #(3)  funct3;
    Bit #(5)  funct5;
@@ -261,7 +276,8 @@ function Decoded_Instr fv_decode (Instr instr);
 			 rs1:       instr_rs1      (instr),
 			 rs2:       instr_rs2      (instr),
 			 rs3:       instr_rs3      (instr),
-			 csr:       instr_csr      (instr),
+			 //csr:       instr_csr      (instr),
+                         csr_scr_addr: instr_csr_scr_addr (instr),
 
 			 funct3:    instr_funct3   (instr),
 			 funct5:    instr_funct5   (instr),
@@ -1027,7 +1043,6 @@ function Bool fn_instr_is_csrrx (Instr  instr);
    let decoded_instr = fv_decode (instr);
    let opcode        = decoded_instr.opcode;
    let funct3        = decoded_instr.funct3;
-   let csr           = decoded_instr.csr;
    return ((opcode == op_SYSTEM) && f3_is_CSRR_any (funct3));
 endfunction
 
@@ -1077,6 +1092,36 @@ endfunction
 function Bool fn_csr_addr_priv_ok (CSR_Addr csr_addr, Priv_Mode priv_mode);
    return (priv_mode >= csr_addr [9:8]);
 endfunction
+
+typedef union tagged {
+   CSR_SCR_RegName RegFile_Index;
+   CSR_Addr        CSR_Address;
+   SCR_Addr        SCR_Address;
+} CSR_SCR_Address deriving (Eq, Bits, FShow);
+
+function CSR_SCR_Address fn_csr_addr_to_regname (CSR_Addr addr);
+   case (addr)
+      csr_addr_mscratch:   return RegFile_Index (CSR_MSCRATCH);
+      csr_addr_sscratch:   return RegFile_Index (CSR_MSCRATCH);
+      csr_addr_dscratch0:  return RegFile_Index (CSR_DSCRATCH0);
+      csr_addr_dscratch1:  return RegFile_Index (CSR_DSCRATCH1);
+      default:             return CSR_Address (addr);
+   endcase
+endfunction
+
+function CSR_SCR_Address fn_scr_addr_to_regname (SCR_Addr addr);
+   case (addr)
+      scr_addr_MTDC:       return RegFile_Index (SCR_MTDC);
+      scr_addr_MScratchC:  return RegFile_Index (SCR_SSCRATCHC);
+
+      scr_addr_STDC:       return RegFile_Index (SCR_STDC);
+      scr_addr_SScratchC:  return RegFile_Index (SCR_SSCRATCHC);
+
+      default:             return SCR_Address (addr);
+   endcase
+endfunction
+
+
 
 // ----------------
 // User-level CSR addresses

--- a/src_Core/ISA/ISA_Decls_CSR.bsv
+++ b/src_Core/ISA/ISA_Decls_CSR.bsv
@@ -2,27 +2,28 @@ package ISA_Decls_CSR;
 // TODO make this `included rather than imported?
 
 typedef enum {
-   //SCR_MTCC,
-   //SCR_MEPCC,
-   //CSR_MTVAL,
-   //CSR_MCAUSE,
-   //SCR_STCC,
-   //SCR_SEPCC,
-   //CSR_STVAL,
-   //CSR_SCAUSE,
-   //SCR_DPCC,
-
+   // machine mode
    SCR_MTDC,
+   SCR_MTCC,
+   SCR_MEPCC,
    SCR_MSCRATCHC,
    CSR_MSCRATCH,
 
+   // supervisor mode
    SCR_STDC,
+   SCR_STCC,
+   SCR_SEPCC,
    SCR_SSCRATCHC,
    CSR_SSCRATCH,
 
+   // debug
+   CSR_TSELECT,
+   CSR_TDATA1,
+   CSR_TDATA2,
+   CSR_TDATA3,
    CSR_DSCRATCH0,
    CSR_DSCRATCH1
-} CSR_SCR_RegName deriving (Eq, Bits, FShow);
+} CSR_SCR_RegName deriving (Eq, Bits, FShow, Bounded);
 
 
 endpackage

--- a/src_Core/ISA/ISA_Decls_CSR.bsv
+++ b/src_Core/ISA/ISA_Decls_CSR.bsv
@@ -1,0 +1,28 @@
+package ISA_Decls_CSR;
+// TODO make this `included rather than imported?
+
+typedef enum {
+   //SCR_MTCC,
+   //SCR_MEPCC,
+   //CSR_MTVAL,
+   //CSR_MCAUSE,
+   //SCR_STCC,
+   //SCR_SEPCC,
+   //CSR_STVAL,
+   //CSR_SCAUSE,
+   //SCR_DPCC,
+
+   SCR_MTDC,
+   SCR_MSCRATCHC,
+   CSR_MSCRATCH,
+
+   SCR_STDC,
+   SCR_SSCRATCHC,
+   CSR_SSCRATCH,
+
+   CSR_DSCRATCH0,
+   CSR_DSCRATCH1
+} CSR_SCR_RegName deriving (Eq, Bits, FShow);
+
+
+endpackage

--- a/src_Core/RegFiles/CSR_RegFile_MSU.bsv
+++ b/src_Core/RegFiles/CSR_RegFile_MSU.bsv
@@ -30,6 +30,7 @@ export  mkCSR_RegFile;
 // BSV library imports
 
 import ConfigReg    :: *;
+import DReg         :: *;
 import RegFile      :: *;
 import Vector       :: *;
 import FIFOF        :: *;
@@ -66,7 +67,6 @@ import CHERICC_Fat  :: *;
 
 import ISA_Decls_CSR :: *;
 
-
 // ================================================================
 // Writing a CSR can update multiple CSRs (e.g., writing
 // FRM/FFLAGS/FCSR also updates MSTATUS.FS and MSTATUS.SD
@@ -90,29 +90,8 @@ interface CSR_RegFile_IFC;
    // Reset
    interface Server #(Token, Token) server_reset;
 
-   // CSR read (w.o. side effect)
-   (* always_ready *)
-   method Maybe #(Word) read_csr (CSR_Addr csr_addr);
    (* always_ready *)
    method Maybe #(Word) read_csr_port2 (CSR_Addr csr_addr);
-`ifdef ISA_CHERI
-   (* always_ready *)
-   method Maybe #(CapReg) read_scr (SCR_Addr scr_addr);
-`endif
-
-   // CSR read (w. side effect)
-   (* always_ready *)
-   method ActionValue #(Maybe #(Word)) mav_read_csr (CSR_Addr csr_addr);
-
-   // CSR write (returning new value)
-   (* always_ready *)
-   method ActionValue #(CSR_Write_Result) mav_csr_write (CSR_Addr csr_addr, WordXL word);
-
-`ifdef ISA_CHERI
-   // SCR write (returning new value)
-   (* always_ready *)
-   method ActionValue #(CapReg) mav_scr_write (SCR_Addr scr_addr, CapReg cap);
-`endif
 
 `ifdef ISA_F
    // Read FRM
@@ -209,9 +188,7 @@ interface CSR_RegFile_IFC;
 
    // Access permission
    (* always_ready *)
-   method AccessPerms access_permitted_1 (Priv_Mode  priv, CSR_Addr  csr_addr, Bool  read_not_write);
-   (* always_ready *)
-   method AccessPerms access_permitted_2 (Priv_Mode  priv, CSR_Addr  csr_addr, Bool  read_not_write);
+   method AccessPerms access_permitted (Priv_Mode  priv, CSR_Addr  csr_addr, Bool  read_not_write);
 `ifdef ISA_CHERI
    (* always_ready *)
    method AccessPerms access_permitted_scr (Priv_Mode  priv, SCR_Addr  scr_addr, Bool  read_not_write);
@@ -285,11 +262,17 @@ interface CSR_RegFile_IFC;
 
    // ----------------
    // Register file access
+   (* always_ready *)
    method Action read_req (CSR_SCR_Address regname);
 
+   (* always_ready *)
    method CapPipe read_rsp ();
 
+   (* always_ready *)
    method ActionValue #(CapPipe) write_req (CSR_SCR_Address regname, CapPipe data);
+
+   (* always_ready *)
+   method CapPipe fv_update_scr_via_csr (CapPipe old_scr, WordXL new_csr, Bool allow_sealed);
 endinterface
 
 // ================================================================
@@ -355,7 +338,7 @@ endfunction
 // ================================================================
 // Major states of mkCSR_RegFile module
 
-typedef enum { RF_RESET_START, RF_RESET_LOOP, RF_RESET_FINISH, RF_RUNNING } RF_State
+typedef enum { RF_RESET_START, RF_RESET_LOOP, RF_RUNNING } RF_State
 deriving (Eq, Bits, FShow);
 
 // ================================================================
@@ -370,7 +353,9 @@ endmodule
 
 // ================================================================
 
+`ifdef SYNTHESIZE_MODULES
 (* synthesize *)
+`endif
 module mkCSR_RegFile (CSR_RegFile_IFC);
 
 `ifdef RVFI_DII
@@ -404,21 +389,11 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
    // scounteren hardwired to 0 for now
 
-   Reg #(Word)       rg_sscratch  <- mkCSRReg;
    Reg #(MCause)     rg_scause    <- mkCSRReg;
 `ifdef ISA_CHERI
+   // STCC, STDC, SEPCC, SSCRATCHC and SSCRATCH are all held in the BRAM
+   // and so are STVEC and SEPC since they extend the SCRs
    Reg #(XCCSR)      rg_sccsr     <- mkCSRReg;
-   Reg #(CapReg)     rg_stcc      <- mkReg(nullCap);
-   CapPipe           rg_stcc_unpacked = cast(rg_stcc);
-   Reg #(CapReg)     rg_stdc      <- mkReg(nullCap);
-   CapPipe           rg_stdc_unpacked = cast(rg_stdc);
-   Reg #(CapReg)     rg_sscratchc <- mkReg(nullCap);
-   CapPipe           rg_sscratchc_unpacked = cast(rg_sscratchc);
-   Reg #(CapReg)     rg_sepcc     <- mkReg(nullCap);
-   CapPipe           rg_sepcc_unpacked = cast(rg_sepcc);
-
-   let               rg_stvec = word_to_mtvec(getOffset(rg_stcc_unpacked));
-   let               rg_sepc  = getOffset(rg_sepcc_unpacked);
 `else
    Reg #(MTVec)      rg_stvec     <- mkCSRReg;
    Reg #(Word)       rg_sepc      <- mkCSRReg;
@@ -448,23 +423,13 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
    Reg #(MCounteren) rg_mcounteren <- mkCSRReg;
 
-   Reg #(Word)       rg_mscratch <- mkCSRReg;
    Reg #(MCause)     rg_mcause   <- mkCSRReg;
    Reg #(Word)       rg_mtval    <- mkCSRReg;
 
 `ifdef ISA_CHERI
+   // MTCC, MTDC, MEPCC, MSCRATCHC and MSCRATCH are all held in the BRAM
+   // and so are MTVEC and MEPC since they extend the SCRs
    Reg #(XCCSR)      rg_mccsr    <- mkCSRReg;
-   Reg #(CapReg)     rg_mtcc      <- mkReg(nullCap);
-   CapPipe           rg_mtcc_unpacked = cast(rg_mtcc);
-   Reg #(CapReg)     rg_mtdc      <- mkReg(nullCap);
-   CapPipe           rg_mtdc_unpacked = cast(rg_mtdc);
-   Reg #(CapReg)     rg_mscratchc <- mkReg(nullCap);
-   CapPipe           rg_mscratchc_unpacked = cast(rg_mscratchc);
-   Reg #(CapReg)     rg_mepcc     <- mkReg(nullCap);
-   CapPipe           rg_mepcc_unpacked = cast(rg_mepcc);
-
-   let               rg_mtvec = word_to_mtvec(getOffset(rg_mtcc_unpacked));
-   let               rg_mepc  = getOffset(rg_mepcc_unpacked);
 `else
    Reg #(MTVec)      rg_mtvec    <- mkCSRReg;
    Reg #(Word)       rg_mepc     <- mkCSRReg;
@@ -507,32 +472,25 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    CSR_Addr no_of_ctrs = 0;
 `endif
 
-   // Debug/Trace
-   Reg #(WordXL)    rg_tselect <- mkCSRReg;
-   Reg #(WordXL)    rg_tdata1  <- mkCSRReg;
-   Reg #(WordXL)    rg_tdata2  <- mkCSRReg;
-   Reg #(WordXL)    rg_tdata3  <- mkCSRReg;
-
    // Debug
+   // dscratch{0,1}, tdata{1,2,3} and tselect are held in the BRAM
    Reg #(Bit #(32)) rg_dcsr      <- mkCSRReg;    // Is 32b even in RV64
    Reg #(CapPipe)   rg_dpcc      <- mkCSRReg;
-   Reg #(WordXL)    rg_dscratch0 <- mkCSRReg;
-   Reg #(WordXL)    rg_dscratch1 <- mkCSRReg;
 
    // Non-maskable interrupt
    Reg #(Bool)    rg_nmi <- mkReg (False);
    Reg #(WordXL)  rg_nmi_vector <- mkCSRReg;
 
-   // ================================================================
-   // BEHAVIOR: RESET
-   // Initialize some CSRs.
+   // BRAM Instantiation
+   BRAM_DUAL_PORT #(CSR_SCR_RegName, CapReg) bram <- mkBRAMCore2 (valueOf (TExp #(SizeOf #(CSR_SCR_RegName))), False);
 
-   //RegFile #(CSR_SCR_RegName, CapReg) regfile <- mkRegFile (unpack (0), CSR_DSCRATCH1);
-   // TODO find a better way of setting this size (first argument is number of CapRegs stored
-   BRAM_DUAL_PORT #(CSR_SCR_RegName, CapReg) bram <- mkBRAMCore2 (15, False);
-   Reg #(Bool) rg_read_from_bram <- mkRegU;
-   Reg #(CapPipe) rg_csr_scr_read_val <- mkRegU;
+   // whether the read value should come directly from BRAM or from reading the CSR whose
+   // address is in rg_csr_addr
+   Reg #(Bool) rg_read_from_bram <- mkDReg (False);
 
+   // the address of the csr that was last requested in read_req. Used for returning requested
+   // CSR reads a cycle later to improve critical path
+   Reg #(CSR_Addr) rg_csr_addr <- mkRegU;
 
    // only use the first port in the BRAM for reads, and only use the second
    // for writing
@@ -540,27 +498,15 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    let read_port = bram.a;
    let write_port = bram.b;
 
-   // TODO make this an appropriate size to cycle through the available
-   // registers
-   Reg #(CSR_SCR_RegName) rg_i <- mkReg ( unpack(0));
+   // ================================================================
+   // BEHAVIOR: RESET
+   // Initialize some CSRs.
+
+   // used to iterate through the BRAM to reset SCR values
+   Reg #(CSR_SCR_RegName) rg_i <- mkRegU;
+
    rule rl_reset_start (rg_state == RF_RESET_START);
-      rg_i <= unpack (0);
-      rg_state <= RF_RESET_LOOP;
-   endrule
-
-   rule rl_reset_loop (rg_state == RF_RESET_LOOP);
-      let next = pack (rg_i) + 1;
-      rg_i <= unpack (next);
-      write_port.put(True, rg_i, nullCap);
-      if (rg_i == CSR_DSCRATCH1) begin
-         // last register is being reset, go to RF_RESET_FINISH
-         // while we still have it
-         // TODO change this to RF_RUNNING when RF_RESET_FINISH is removed
-         rg_state <= RF_RESET_FINISH;
-      end
-   endrule
-
-   rule rl_reset_finish (rg_state == RF_RESET_FINISH);
+      // reset hardware register values
       // User-level CSRs
 `ifdef ISA_F
       rg_fflags <= 0;
@@ -570,8 +516,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       // Supervisor-level CSRs
 `ifdef ISA_PRIV_S
 `ifdef ISA_CHERI
-      rg_stcc       <= soc_map.m_mtcc_reset_value;
-      rg_sepcc      <= soc_map.m_mepcc_reset_value;
       rg_sccsr      <= XCCSR{cheri_exc_code: 0, cheri_exc_reg: 0};
 `else
       rg_stvec    <= word_to_mtvec (truncate (soc_map.m_mtvec_reset_value));
@@ -587,8 +531,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       csr_mip.reset;
 
 `ifdef ISA_CHERI
-      rg_mtcc       <= soc_map.m_mtcc_reset_value;
-      rg_mepcc      <= soc_map.m_mepcc_reset_value;
       rg_mccsr      <= XCCSR{cheri_exc_code: 0, cheri_exc_reg: 0};
 `else
       rg_mtvec      <= word_to_mtvec (truncate (soc_map.m_mtvec_reset_value));
@@ -599,9 +541,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       rg_mideleg    <= 0;
 `endif
       rg_mcounteren <= mcounteren_reset_value;
-
-      rg_tselect    <= 0;
-      rg_tdata1     <= 0;    // ISA test rv64mi-p-breakpoint assumes reset value 0.
 
       rw_minstret.wset (0);
 
@@ -633,7 +572,28 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       rg_nmi        <= False;
       rg_nmi_vector <= truncate (soc_map.m_nmivec_reset_value);
 
-      rg_state <= RF_RUNNING;
+      // start looping through the BRAM
+      rg_i <= minBound;
+      rg_state <= RF_RESET_LOOP;
+   endrule
+
+   rule rl_reset_loop (rg_state == RF_RESET_LOOP);
+      case (rg_i)
+         SCR_MTCC, SCR_MEPCC, SCR_STCC, SCR_SEPCC: begin
+            write_port.put (True, rg_i, almightyCap);
+         end
+         default: begin
+            write_port.put(True, rg_i, nullCap);
+         end
+      endcase
+
+      if (rg_i == maxBound) begin
+         // we've just reset the last SCR register, so the reset is finished
+         rg_state <= RF_RUNNING;
+      end
+
+      let next = pack (rg_i) + 1;
+      rg_i <= unpack (next);
    endrule
 
    // ================================================================
@@ -857,30 +817,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    endfunction
 `endif
 
-`ifdef ISA_CHERI
-   function Maybe #(CapReg) fv_scr_read (SCR_Addr scr_addr);
-       Maybe #(CapReg) m_scr_value = tagged Invalid;
-
-       case (scr_addr)
-           //pcc and ddc handled externally
-
-`ifdef ISA_PRIV_S
-           scr_addr_STCC: m_scr_value = tagged Valid rg_stcc;
-           scr_addr_STDC: m_scr_value = tagged Valid rg_stdc;
-           scr_addr_SScratchC: m_scr_value = tagged Valid rg_sscratchc;
-           scr_addr_SEPCC: m_scr_value = tagged Valid rg_sepcc;
-`endif
-
-           scr_addr_MTCC: m_scr_value = tagged Valid rg_mtcc;
-           scr_addr_MTDC: m_scr_value = tagged Valid rg_mtdc;
-           scr_addr_MScratchC: m_scr_value = tagged Valid rg_mscratchc;
-           scr_addr_MEPCC: m_scr_value = tagged Valid rg_mepcc;
-       endcase
-
-       return m_scr_value;
-   endfunction
-`endif
-
    // ----------------
    // CSR reads (no side effect)
    // Returns Invalid for invalid CSR addresses or access-mode violations
@@ -954,11 +890,8 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	    csr_addr_sedeleg:    m_csr_value = tagged Valid zeroExtend (sedeleg);
 	    csr_addr_sideleg:    m_csr_value = tagged Valid zeroExtend (sideleg);
 	    csr_addr_sie:        m_csr_value = tagged Valid (csr_mie.mv_sie_read);
-	    csr_addr_stvec:      m_csr_value = tagged Valid (mtvec_to_word (rg_stvec));
 	    csr_addr_scounteren: m_csr_value = tagged Valid 0;
 
-	    csr_addr_sscratch:   m_csr_value = tagged Valid rg_sscratch;
-	    csr_addr_sepc:       m_csr_value = tagged Valid ((misa.c == 1'b1) ? rg_sepc : (rg_sepc & (~ 2)));
 	    csr_addr_scause:     m_csr_value = tagged Valid (mcause_to_word (rg_scause));
 	    csr_addr_stval:      m_csr_value = tagged Valid rg_stval;
 	    csr_addr_sip:        m_csr_value = tagged Valid (csr_mip.mv_sip_read);
@@ -981,11 +914,8 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	    csr_addr_mstatus:    m_csr_value = tagged Valid (csr_mstatus.mv_read);
 	    csr_addr_misa:       m_csr_value = tagged Valid (misa_to_word (misa));
 	    csr_addr_mie:        m_csr_value = tagged Valid (csr_mie.mv_read);
-	    csr_addr_mtvec:      m_csr_value = tagged Valid (mtvec_to_word (rg_mtvec));
 	    csr_addr_mcounteren: m_csr_value = tagged Valid (mcounteren_to_word (rg_mcounteren));
 
-	    csr_addr_mscratch:   m_csr_value = tagged Valid rg_mscratch;
-	    csr_addr_mepc:       m_csr_value = tagged Valid ((misa.c == 1'b1) ? rg_mepc : (rg_mepc & (~ 2)));
 	    csr_addr_mcause:     m_csr_value = tagged Valid (mcause_to_word (rg_mcause));
 	    csr_addr_mtval:      m_csr_value = tagged Valid rg_mtval;
 	    csr_addr_mip:        m_csr_value = tagged Valid (csr_mip.mv_read);
@@ -1026,11 +956,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
 	    csr_addr_mcountinhibit: m_csr_value = tagged Valid ctr_inhibit;
 
-	    csr_addr_tselect:  m_csr_value = tagged Valid rg_tselect;
-	    csr_addr_tdata1:   m_csr_value = tagged Valid rg_tdata1;
-	    csr_addr_tdata2:   m_csr_value = tagged Valid rg_tdata2;
-	    csr_addr_tdata3:   m_csr_value = tagged Valid rg_tdata3;
-
 `ifdef INCLUDE_GDB_CONTROL
 	    csr_addr_dcsr:       begin
 				    Bit #(32) dcsr_nmip_mask = 'b_1000;
@@ -1040,8 +965,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 				    m_csr_value = tagged Valid zeroExtend (dcsr);
 				 end
 	    csr_addr_dpc:        m_csr_value = tagged Valid getOffset(rg_dpcc);
-	    csr_addr_dscratch0:  m_csr_value = tagged Valid rg_dscratch0;
-	    csr_addr_dscratch1:  m_csr_value = tagged Valid rg_dscratch1;
 `endif
 
 	    default: m_csr_value = tagged Invalid;
@@ -1165,33 +1088,8 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	       csr_addr_sie:        begin
 				       new_csr_value <- csr_mie.mav_sie_write (misa, wordxl);
 				    end
-	       csr_addr_stvec:      begin
-				       let stvec     = word_to_mtvec (wordxl);
-				       new_csr_value = mtvec_to_word (stvec);
-`ifdef ISA_CHERI
-				       rg_stcc      <= cast(update_scr_via_csr(rg_stcc_unpacked, new_csr_value, False));
-`else
-				       rg_stvec     <= stvec;
-`endif
-				    end
 	       csr_addr_scounteren: new_csr_value = 0;    // Hardwired to zero
 
-	       csr_addr_sscratch:   begin
-				       new_csr_value = wordxl;
-				       rg_sscratch  <= new_csr_value;
-				    end
-	       csr_addr_sepc:       begin
-`ifdef ISA_C
-				       new_csr_value = (wordxl & (~ 1));    // sepc [0] always zero
-`else
-				       new_csr_value = (wordxl & (~ 3));    // sepc [1:0] always zero
-`endif
-`ifdef ISA_CHERI
-				       rg_sepcc     <= cast(update_scr_via_csr(rg_sepcc_unpacked, new_csr_value, False));
-`else
-				       rg_sepc      <= new_csr_value;
-`endif
-				    end
 	       csr_addr_scause:     begin
 				       let mcause    = word_to_mcause (wordxl);
 				       new_csr_value = mcause_to_word (mcause);
@@ -1240,35 +1138,10 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	       csr_addr_mie:        begin
 				       new_csr_value <- csr_mie.mav_write (misa, wordxl);
 				    end
-	       csr_addr_mtvec:      begin
-				       let mtvec     = word_to_mtvec (wordxl);
-				       new_csr_value = mtvec_to_word (mtvec);
-`ifdef ISA_CHERI
-				       rg_mtcc      <= cast(update_scr_via_csr(rg_mtcc_unpacked, new_csr_value, False));
-`else
-				       rg_mtvec     <= mtvec;
-`endif
-				    end
 	       csr_addr_mcounteren: begin
 				       let mcounteren = word_to_mcounteren(wordxl);
 				       new_csr_value  = mcounteren_to_word (mcounteren);
 				       rg_mcounteren <= mcounteren;
-				    end
-	       csr_addr_mscratch:   begin
-				       new_csr_value = wordxl;
-				       rg_mscratch  <= new_csr_value;
-				    end
-	       csr_addr_mepc:       begin
-`ifdef ISA_C
-				       new_csr_value = (wordxl & (~ 1));    // mepc [0] always zero
-`else
-				       new_csr_value = (wordxl & (~ 3));    // mepc [1:0] always zero
-`endif
-`ifdef ISA_CHERI
-				       rg_mepcc     <= cast(update_scr_via_csr(rg_mepcc_unpacked, new_csr_value, False));
-`else
-				       rg_mepc      <= new_csr_value;
-`endif
 				    end
 	       csr_addr_mcause:     begin
 				       let mcause    = word_to_mcause (wordxl);
@@ -1344,28 +1217,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 				       new_csr_value = 0;
 `endif
 				   end
-	       csr_addr_tselect:   begin
-				      // Until we implement trigger functionality,
-				      // return tselect always contains 0
-				      new_csr_value = 0;    // wordxl
-				      rg_tselect   <= new_csr_value;
-				   end
-	       csr_addr_tdata1:    begin
-				      // Until we implement trigger functionality,
-				      // force 'type' field ([xlen-1:xlen-4]) to zero
-				      // meaning: 'There is no trigger at this tselect'
-				      new_csr_value = (wordxl & ('1 >> 4));
-				      rg_tdata1    <= new_csr_value;
-				   end
-	       csr_addr_tdata2:    begin
-				      new_csr_value = wordxl;
-				      rg_tdata2    <= new_csr_value;
-				   end
-	       csr_addr_tdata3:    begin
-				      new_csr_value = wordxl;
-				      rg_tdata3    <= new_csr_value;
-				   end
-
 `ifdef INCLUDE_GDB_CONTROL
 	       csr_addr_dcsr:       begin
 				       Bit #(32) new_dcsr
@@ -1386,14 +1237,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 				       new_csr_value = wordxl;
 				       rg_dpcc      <= setOffset(rg_dpcc, new_csr_value).value; //TODO unrepresentable?
 				    end
-	       csr_addr_dscratch0:  begin
-				       new_csr_value = wordxl;
-				       rg_dscratch0 <= new_csr_value;
-				    end
-	       csr_addr_dscratch1:  begin
-				       new_csr_value = wordxl;
-				       rg_dscratch1 <= new_csr_value;
-				    end
 `endif
 
 	       default: success = False;
@@ -1407,90 +1250,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 				  m_new_csr_value2: m_new_csr_value2};
       endactionvalue
    endfunction: fav_csr_write
-
-`ifdef ISA_CHERI
-
-   // ----------------------------------------------------------------
-   // SCR writes
-
-   function ActionValue #(CapReg) fav_scr_write (SCR_Addr scr_addr, CapReg cap);
-      actionvalue
-	 Bool    success = True;
-	 CapReg  result  = nullCap;
-	 CapPipe capUnpacked = cast(cap);
-
-	    case (scr_addr)
-`ifdef ISA_PRIV_S
-         scr_addr_STCC: begin
-             capUnpacked = update_scr_via_csr(capUnpacked, mtvec_to_word(word_to_mtvec(getOffset(capUnpacked))), False);
-             // This can be done much more efficiently by breaking into the compressed cap format
-             if (getBaseAlignment(capUnpacked) == 0) begin
-                rg_stcc <= cast(capUnpacked);
-                result = cast(capUnpacked);
-             end
-         end
-         scr_addr_STDC: begin
-             rg_stdc <= cap;
-             result = cap;
-         end
-         scr_addr_SEPCC: begin
-             let newOffset = getOffset(capUnpacked);
-`ifdef ISA_C
-             Bool changeMade = newOffset[0] != 1'b0;
-             newOffset[0] = 1'b0;
-`else
-             Bool changeMade = newOffset[1:0] != 2'b0;
-             newOffset[1:0] = 2'b0;
-`endif
-             capUnpacked = update_scr_via_csr(capUnpacked, newOffset, !changeMade);
-             rg_sepcc <= cast(capUnpacked);
-             result = cast(capUnpacked);
-         end
-         scr_addr_SScratchC: begin
-             rg_sscratchc <= cap;
-             result = cap;
-         end
-`endif
-         scr_addr_MTCC: begin
-             capUnpacked = update_scr_via_csr(capUnpacked, mtvec_to_word(word_to_mtvec(getOffset(capUnpacked))), False);
-             // This can be done much more efficiently by breaking into the compressed cap format
-             if (getBaseAlignment(capUnpacked) == 0) begin
-                rg_mtcc <= cast(capUnpacked);
-                result = cast(capUnpacked);
-             end
-         end
-         scr_addr_MTDC: begin
-             rg_mtdc <= cap;
-             result = cap;
-         end
-         scr_addr_MEPCC: begin
-             let newOffset = getOffset(capUnpacked);
-`ifdef ISA_C
-             Bool changeMade = newOffset[0] != 1'b0;
-             newOffset[0] = 1'b0;
-`else
-             Bool changeMade = newOffset[1:0] != 2'b0;
-             newOffset[1:0] = 2'b0;
-`endif
-             capUnpacked = update_scr_via_csr(capUnpacked, newOffset, !changeMade);
-             rg_mepcc <= cast(capUnpacked);
-             result = cast(capUnpacked);
-         end
-         scr_addr_MScratchC: begin
-             rg_mscratchc <= cap;
-             result = cap;
-         end
-	       default: success = False;
-	    endcase
-
-	 if ((! success) && (cfg_verbosity > 1))
-	    $display ("%0d: ERROR: SCR-write addr 0x%0h val ", rg_mcycle, scr_addr, fshow(cap), " not successful");
-
-	 return result;
-      endactionvalue
-   endfunction: fav_scr_write
-
-`endif
 
    // Access permission
    function AccessPerms fv_access_permitted (Priv_Mode  priv, CSR_Addr  csr_addr,  Bool read_not_write);
@@ -1587,39 +1346,9 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    endinterface
 
    // CSR read (w.o. side effect)
-   method Maybe #(Word) read_csr (CSR_Addr csr_addr);
-      return fv_csr_read (csr_addr);
-   endmethod
-
-   // CSR read (w.o. side effect)
    method Maybe #(Word) read_csr_port2 (CSR_Addr csr_addr);
       return fv_csr_read (csr_addr);
    endmethod
-
-`ifdef ISA_CHERI
-   method Maybe #(CapReg) read_scr (SCR_Addr scr_addr);
-      return fv_scr_read (scr_addr);
-   endmethod
-`endif
-
-   // CSR read (w. side effect)
-   method ActionValue #(Maybe #(Word)) mav_read_csr (CSR_Addr csr_addr);
-      return fv_csr_read (csr_addr);
-   endmethod
-
-   // CSR write
-   method ActionValue #(CSR_Write_Result) mav_csr_write (CSR_Addr csr_addr, WordXL word);
-      let result <- fav_csr_write (csr_addr, word);
-      return result;
-   endmethod
-
-`ifdef ISA_CHERI
-   // SCR write
-   method ActionValue #(CapReg) mav_scr_write (SCR_Addr scr_addr, CapReg cap);
-      let result <- fav_scr_write (scr_addr, cap);
-      return result;
-   endmethod
-`endif
 
    // Read MISA
    method MISA read_misa;
@@ -1685,6 +1414,8 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    endmethod
 
    // CSR Trap actions
+   // In CHERI, a read request to xTCC is required the cycle before this
+   // is invoked
    method ActionValue #(Trap_Info_CSR)
           csr_trap_actions (Priv_Mode  from_priv,
 `ifdef ISA_CHERI
@@ -1711,6 +1442,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
        pc
 `endif
                      , pack (interrupt), exc_code, xtval);
+`ifndef ISA_CHERI
 `ifdef ISA_PRIV_S
 	 fa_show_trap_csrs (s_Priv_Mode, csr_mip.mv_read, csr_mie.mv_read, 0, 0, rg_scause,
 			    csr_mstatus.mv_sstatus_read,
@@ -1719,6 +1451,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	 fa_show_trap_csrs (m_Priv_Mode, csr_mip.mv_read, csr_mie.mv_read, rg_medeleg, rg_mideleg, rg_mcause,
 			    csr_mstatus.mv_read,
 			    rg_mtvec, rg_mepc, rg_mtval);
+`endif
       end
 
       let new_priv    = (nmi
@@ -1737,30 +1470,48 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 `ifdef ISA_CHERI
       let capexc = XCCSR {cheri_exc_reg: cheri_exc_reg, cheri_exc_code: cheri_exc_code};
       if (exc_code == exc_code_CHERI) xtval = capexc_to_xtval(capexc);
-      let xtcc = ?;
+
+      // In the cycle before this was called, we would have already selected between STCC and MTCC
+      CapPipe xtcc = cast (read_port.read);
+      WordXL xtcc_offset = getOffset (xtcc);
+      let xtvec = word_to_mtvec (xtcc_offset);
 `endif
 
       let  xcause      = (nmi
 			  ? MCause {interrupt: 0, exc_code: 0 }
 			  : MCause {interrupt: pack (interrupt), exc_code: exc_code});
-      let  is_vectored = (rg_mtvec.mode == VECTORED);
+      let  is_vectored = (xtvec.mode == VECTORED);
+`ifdef ISA_CHERI
+      // only used for debug printing
+      Addr exc_pc      = (extend (xtvec.base)) << 2;
+`ifdef ISA_C
+      Addr exc_addr    = {truncateLSB (getAddr (xtcc)), 1'b0};
+`else
+      Addr exc_addr    = {truncateLSB (getAddr (xtcc)), 2'b00};
+`endif
+`else
       Addr exc_pc      = (extend (rg_mtvec.base)) << 2;
+`endif
 
       if (nmi) begin
 `ifdef ISA_CHERI
-   rg_mepcc   <= cast(pcc);
+         write_port.put (True, SCR_MEPCC, cast (pcc));
 `else
 	 rg_mepc    <= pc;
 `endif
 	 rg_mtval   <= xtval;
 	 rg_mcause  <= xcause;
+	 // TODO when CHERI is enabled, exc_pc is only used for debug printing.
+         // This means that for vectored interrupts the new PCC doesn't get
+         // offset using the interrupt code.
 	 exc_pc      = rg_nmi_vector;
+	 // potential solution (quite costly):
+	 //exc_addr    = getBase (xtcc) + rg_nmi_vector;
 	 is_vectored = False;
       end
       else if (new_priv == m_Priv_Mode) begin
 `ifdef ISA_CHERI
-   rg_mepcc   <= cast(pcc);
-   xtcc        = rg_mtcc_unpacked;
+         write_port.put (True, SCR_MEPCC, cast (pcc));
 	 if (exc_code == exc_code_CHERI) rg_mccsr   <= capexc;
 `else
 	 rg_mepc    <= pc;
@@ -1771,27 +1522,41 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 `ifdef ISA_PRIV_S
       else if (new_priv == s_Priv_Mode) begin
 `ifdef ISA_CHERI
-   rg_sepcc   <= cast(pcc);
-   xtcc        = rg_stcc_unpacked;
-   if (exc_code == exc_code_CHERI) rg_sccsr   <= capexc;
+         write_port.put (True, SCR_SEPCC, cast (pcc));
+         if (exc_code == exc_code_CHERI) rg_sccsr   <= capexc;
 `else
 	 rg_sepc    <= pc;
 `endif
 	 rg_scause  <= xcause;
 	 rg_stval   <= xtval;
 
-	 is_vectored = (rg_stvec.mode == VECTORED);
 	 new_status  = fv_mstatus_to_sstatus (new_status);
-	 exc_pc      = (extend (rg_stvec.base)) << 2;
+`ifndef ISA_CHERI
+	 is_vectored = (xtvec.mode == VECTORED);
+	 exc_pc      = (extend (xtvec.base)) << 2;
+`endif
       end
 `endif
       // TODO: if (new_priv == u_Priv_Mode)
 
       // Adjust the exception PC if xTVEC mode bits so indicate
+`ifdef ISA_CHERI
+      CapPipe exc_pcc = xtcc;
+`endif
       Addr vector_offset = (extend (exc_code)) << 2;
-      if (interrupt && is_vectored)
+      if (interrupt && is_vectored) begin
+         // unused in CHERI, apart from for debug printing
 	 exc_pc = exc_pc + vector_offset;
-   CapPipe exc_pcc  = setOffset(xtcc, exc_pc).value; //TODO representability check
+`ifdef ISA_CHERI
+         // In RV64, addAddrUnsafe takes an 11 bit input as its second argument.
+         // In RV32 the same argument is only 5 bits.
+         // The RISCV specification specifies at 16 different exception codes, which
+         // need 4 bits to be enumerated, so our offset needs to be at least 6 bits
+         // which is too big to be passed as the second element to an addAddrUnsafe
+         exc_addr = exc_addr + vector_offset;
+`endif
+      end
+      exc_pcc = setAddrUnsafe (xtcc, exc_addr); // TODO representability?
 
       if (cfg_verbosity > 1) begin
 	 $write ("    Return: new pc 0x%0h  ", exc_pc);
@@ -1813,6 +1578,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    endmethod: csr_trap_actions
 
    // CSR RET actions (return from exception)
+   // In CHERI, a read request to xEPCC is required the cycle before this is invoked
    method ActionValue #(Tuple3 #(
 `ifdef ISA_CHERI
 				 CapPipe,
@@ -1822,11 +1588,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 				 Priv_Mode, Word)) csr_ret_actions (Priv_Mode from_priv);
       match { .new_mstatus, .to_priv } = fv_new_mstatus_on_ret (misa, csr_mstatus.mv_read, from_priv);
       csr_mstatus.ma_write (misa, new_mstatus);
-      CapPipe next_pcc = rg_mepcc_unpacked;
-`ifdef ISA_PRIV_S
-      if (from_priv != m_Priv_Mode)
-	 next_pcc = rg_sepcc_unpacked;
-`endif
+      CapPipe next_pcc = cast (read_port.read);
       if (getKind(next_pcc) == SENTRY)
          next_pcc = setKind(next_pcc, UNSEALED);
       return tuple3 (
@@ -1873,11 +1635,7 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 `endif
 
    // Access permission
-   method AccessPerms access_permitted_1 (Priv_Mode  priv, CSR_Addr  csr_addr,  Bool read_not_write);
-      return fv_access_permitted (priv, csr_addr, read_not_write);
-   endmethod
-
-   method AccessPerms access_permitted_2 (Priv_Mode  priv, CSR_Addr  csr_addr,  Bool read_not_write);
+   method AccessPerms access_permitted (Priv_Mode  priv, CSR_Addr  csr_addr,  Bool read_not_write);
       return fv_access_permitted (priv, csr_addr, read_not_write);
    endmethod
 
@@ -1957,8 +1715,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 
 `ifdef INCLUDE_GDB_CONTROL
    // Read dpcc
-   // TODO will need to split this into multiple cycles
-   // Otherwise the regfile won't be inferred
    method CapPipe read_dpcc ();
       return rg_dpcc;
    endmethod
@@ -1978,15 +1734,11 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    endmethod
 
    // Read dcsr.step
-   // TODO need to split this into multiple actions, or split off this particular
-   // bit of the register and store it in a Reg #(Bool)
    method Bool read_dcsr_step ();
       return unpack (rg_dcsr [2]);
    endmethod
 
    // Update 'cause' and 'priv' in DCSR
-   // TODO will need to split this into multiple cycles
-   // Otherwise the regfile won't be inferred
    method Action write_dcsr_cause_priv (DCSR_Cause  cause, Priv_Mode  priv);
       Bit #(3) b3 = pack (cause);
       rg_dcsr <= { rg_dcsr [31:9], b3, rg_dcsr [5:2], priv };
@@ -2015,7 +1767,9 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
    // ----------------
    // Register file access
    method Action read_req (CSR_SCR_Address addr);
-      $display ("read request registered. addr: ", fshow(addr));
+      if (cfg_verbosity > 1) begin
+         $display ("read request registered. addr: ", fshow(addr));
+      end
       case (addr) matches
          tagged RegFile_Index .name: begin
             read_port.put (False, name, ?);
@@ -2023,16 +1777,14 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
          end
          tagged CSR_Address .csr_addr: begin
             rg_read_from_bram <= False;
-            let read_val = fv_csr_read (csr_addr);
-            if (isValid (read_val)) begin
-               rg_csr_scr_read_val <= nullWithAddr (read_val.Valid);
-            end
+            rg_csr_addr <= csr_addr;
          end
          tagged SCR_Address .scr_addr: begin
-            rg_read_from_bram <= False;
-            let read_val = fv_scr_read (scr_addr);
-            if (isValid (read_val)) begin
-               rg_csr_scr_read_val <= cast (read_val.Valid);
+            // SCR that has not been implemented using the register file
+            // currently there are none of these, so this should never happen
+            // when executing correctly
+            if (cfg_verbosity > 1) begin
+               $display ("illegal scr access to addr ", fshow (addr));
             end
          end
       endcase
@@ -2042,26 +1794,69 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
       if (rg_read_from_bram) begin
          return cast (read_port.read);
       end else begin
-         return rg_csr_scr_read_val;
+         let read_val = fv_csr_read (rg_csr_addr);
+         if (isValid (read_val)) begin
+            return nullWithAddr (read_val.Valid);
+         end else begin
+            return ?;
+         end
       end
    endmethod
 
    method ActionValue #(CapPipe) write_req (CSR_SCR_Address addr, CapPipe data);
-      $display ("write request, addr: ", fshow (addr), " value: ", fshow(data));
+      if (cfg_verbosity > 1) begin
+         $display ("write request, addr: ", fshow (addr), " value: ", fshow(data));
+      end
+      let val_to_write = data;
+      Bit #(2) base_lsb = getBaseAlignment (data);
       case (addr) matches
          tagged RegFile_Index .name: begin
-            write_port.put (True, name, cast (data));
-            return data;
+            // set the LSBs for SCRs that need it
+            case (name)
+               SCR_MEPCC, SCR_SEPCC: begin
+`ifdef ISA_C
+                  let new_addr = {truncateLSB (getAddr (data)), base_lsb[0]};
+`else
+                  let new_addr = {truncateLSB (getAddr (data)), base_lsb};
+`endif
+                  val_to_write = setAddrUnsafe (data, new_addr);
+               end
+               SCR_MTCC, SCR_STCC: begin
+                  val_to_write = maskAddr (data, signExtend (3'b101));
+               end
+            endcase
+            // if trying to write xTCC with a base that is not 4-byte aligned,
+            // don't write anything
+            if ((name != SCR_MTCC && name != SCR_STCC) || base_lsb == 0) begin
+               write_port.put (True, name, cast (val_to_write));
+               return val_to_write;
+            end else begin
+               // TODO find a better thing to return. Perhaps a Maybe?
+               return nullCap;
+            end
          end
          tagged CSR_Address .csr_addr: begin
             let tmp <- fav_csr_write (csr_addr, getAddr (data));
             return nullWithAddr (tmp.new_csr_value);
          end
          tagged SCR_Address .scr_addr: begin
-            let tmp <- fav_scr_write (scr_addr, cast (data));
-            return cast (tmp);
+            // SCR that has not been implemented using the register file
+            // currently there are none of these, so this should never happen
+            // when executing correctly
+            if (cfg_verbosity > 1) begin
+               $display ("illegal scr write to addr ", fshow (addr), " with data ", fshow (data));
+            end
+            return ?;
          end
       endcase
+   endmethod
+
+   // This is defined here in order to allow sharing of the update_scr_via_csr function instantiation.
+   // Without this sharing, invoking the function multiple times in separate rules instantiates the
+   // hardware multiple times, whereas with the sharing it uses the same hardware and passes the
+   // different arguments to the hardware instantiation of the function.
+   method CapPipe fv_update_scr_via_csr (CapPipe old_scr, WordXL new_csr, Bool allow_sealed);
+      return update_scr_via_csr (old_scr, new_csr, allow_sealed);
    endmethod
 endmodule
 

--- a/src_Core/RegFiles/CSR_RegFile_MSU.bsv
+++ b/src_Core/RegFiles/CSR_RegFile_MSU.bsv
@@ -90,9 +90,6 @@ interface CSR_RegFile_IFC;
    // Reset
    interface Server #(Token, Token) server_reset;
 
-   (* always_ready *)
-   method Maybe #(Word) read_csr_port2 (CSR_Addr csr_addr);
-
 `ifdef ISA_F
    // Read FRM
    (* always_ready *)
@@ -1344,11 +1341,6 @@ module mkCSR_RegFile (CSR_RegFile_IFC);
 	 endmethod
       endinterface
    endinterface
-
-   // CSR read (w.o. side effect)
-   method Maybe #(Word) read_csr_port2 (CSR_Addr csr_addr);
-      return fv_csr_read (csr_addr);
-   endmethod
 
    // Read MISA
    method MISA read_misa;


### PR DESCRIPTION
This updates the CSR/SCR register file to use a BRAM to hold all SCRs and some CSRs. It changes the register file to use a request/response protocol rather than the method that was used before.

CSR/SCR accesses have to be registered the cycle before they are required. In most cases this is easily doable without major changes, since the CSR or SCR address is available in that earlier cycle. However there are two cases in which this requires some significant changes: reading CSRs in Debug mode requires an extra cycle, and xRET instructions require an extra cycle.

Let me know what needs to be improved on.