### PR TITLE
Move endif to correct position

### DIFF
--- a/src_Core/CPU/CPU_Globals.bsv
+++ b/src_Core/CPU/CPU_Globals.bsv
@@ -520,6 +520,7 @@ typedef enum {  OP_Stage2_ALU         // Pass-through (non mem, M, FD, AMO)
 `endif
 `ifdef ISA_CHERI
               , OP_Stage2_TestSubset
+`endif
    } Op_Stage2
 deriving (Eq, Bits, FShow);
 

--- a/src_Core/CPU/CPU_Stage2.bsv
+++ b/src_Core/CPU/CPU_Stage2.bsv
@@ -308,6 +308,7 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
 `ifdef RVFI
           let info_RVFI_s2 = info_RVFI_s2_base;
           data_to_stage3.info_RVFI_s2 = info_RVFI_s2;
+`endif
           output_stage2 = Output_Stage2 {ostatus:         ostatus,
                  trap_info:       trap_info_dmem,
 `ifdef PERFORMANCE_MONITORING
@@ -319,7 +320,6 @@ module mkCPU_Stage2 #(Bit #(4)         verbosity,
                , trace_data:      ?
 `endif
                                         };
-`endif
       end
 `endif
 


### PR DESCRIPTION
Right now `data_to_stage3` is a dead variable if `RVFI` is not used.