### PR TITLE
Decouple register addressing

### DIFF
--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -1341,7 +1341,7 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = scr_val;
 
-	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
 
    CapPipe new_scr_val_unpacked = cast(scr_val);
 
@@ -1491,9 +1491,9 @@ module mkCPU (CPU_IFC);
 	 let new_rd_val = csr_val;
 
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (getGPRAddr(rd,0), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
 `endif
 
 	 // Writeback to CSR file
@@ -1631,9 +1631,9 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = csr_val;
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (getGPRAddr(rd,0), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
 `endif
 
 	 // Writeback to CSR file, but only if rs1 != 0

--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -1341,7 +1341,7 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = scr_val;
 
-	 gpr_regfile.write_rd (rd, new_rd_val);
+	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
 
    CapPipe new_scr_val_unpacked = cast(scr_val);
 
@@ -1491,9 +1491,9 @@ module mkCPU (CPU_IFC);
 	 let new_rd_val = csr_val;
 
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (rd, nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (getGPRAddr(rd,0), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (rd, new_rd_val);
+	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
 `endif
 
 	 // Writeback to CSR file
@@ -1631,9 +1631,9 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = csr_val;
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (rd, nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (getGPRAddr(rd,0), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (rd, new_rd_val);
+	 gpr_regfile.write_rd (getGPRAddr(rd,0), new_rd_val);
 `endif
 
 	 // Writeback to CSR file, but only if rs1 != 0

--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -1341,7 +1341,7 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = scr_val;
 
-	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_addr(rd), new_rd_val);
 
    CapPipe new_scr_val_unpacked = cast(scr_val);
 
@@ -1491,9 +1491,9 @@ module mkCPU (CPU_IFC);
 	 let new_rd_val = csr_val;
 
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (get_GPR_addr(rd), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_addr(rd), new_rd_val);
 `endif
 
 	 // Writeback to CSR file
@@ -1631,9 +1631,9 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = csr_val;
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (get_GPR_addr(rd), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_addr(rd), new_rd_val);
 `endif
 
 	 // Writeback to CSR file, but only if rs1 != 0

--- a/src_Core/CPU/CPU.bsv
+++ b/src_Core/CPU/CPU.bsv
@@ -1341,7 +1341,7 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = scr_val;
 
-	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
 
    CapPipe new_scr_val_unpacked = cast(scr_val);
 
@@ -1491,9 +1491,9 @@ module mkCPU (CPU_IFC);
 	 let new_rd_val = csr_val;
 
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
 `endif
 
 	 // Writeback to CSR file
@@ -1631,9 +1631,9 @@ module mkCPU (CPU_IFC);
 	 // Writeback to GPR file
 	 let new_rd_val = csr_val;
 `ifdef ISA_CHERI
-	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), nullWithAddr(new_rd_val));
+	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), nullWithAddr(new_rd_val));
 `else
-	 gpr_regfile.write_rd (getPhysRegAddr(rd,0), new_rd_val);
+	 gpr_regfile.write_rd (get_GPR_reg_addr(rd), new_rd_val);
 `endif
 
 	 // Writeback to CSR file, but only if rs1 != 0

--- a/src_Core/CPU/CPU_Globals.bsv
+++ b/src_Core/CPU/CPU_Globals.bsv
@@ -20,6 +20,7 @@ package CPU_Globals;
 // Project imports
 
 import ISA_Decls :: *;
+import GPR_RegFile :: *;
 
 `ifdef ISA_CHERI
 import CHERICap :: *;
@@ -127,7 +128,7 @@ deriving (Eq, Bits, FShow);
 
 typedef struct {
    Bypass_State  bypass_state;
-   RegName       rd;
+   RegAddr       rd;
 `ifdef ISA_CHERI
    CapPipe       rd_val;
 `else
@@ -152,7 +153,7 @@ endinstance
 `ifdef ISA_F
 typedef struct {
    Bypass_State  bypass_state;
-   RegName       rd;
+   RegAddr       rd;
    WordFL        rd_val;
    } FBypass
 deriving (Bits);
@@ -190,9 +191,9 @@ FBypass no_fbypass = FBypass {bypass_state: BYPASS_RD_NONE,
 // 'busy' means that the RegName is valid and matches, but the value is not available yet
 
 `ifdef ISA_CHERI
-function Tuple2 #(Bool, CapPipe) fn_gpr_bypass (Bypass bypass, RegName rd, CapPipe rd_val);
+function Tuple2 #(Bool, CapPipe) fn_gpr_bypass (Bypass bypass, RegAddr rd, CapPipe rd_val);
 `else
-function Tuple2 #(Bool, Word) fn_gpr_bypass (Bypass bypass, RegName rd, Word rd_val);
+function Tuple2 #(Bool, Word) fn_gpr_bypass (Bypass bypass, RegAddr rd, Word rd_val);
 `endif
    Bool busy = ((bypass.bypass_state == BYPASS_RD) && (bypass.rd == rd));
    let val = (  ((bypass.bypass_state == BYPASS_RD_RDVAL) && (bypass.rd == rd))
@@ -206,7 +207,7 @@ endfunction
 // Returns '(busy, val)'
 // 'busy' means that the RegName is valid and matches, but the value is not available yet
 
-function Tuple2 #(Bool, WordFL) fn_fpr_bypass (FBypass bypass, RegName rd, WordFL rd_val);
+function Tuple2 #(Bool, WordFL) fn_fpr_bypass (FBypass bypass, RegAddr rd, WordFL rd_val);
    Bool busy = ((bypass.bypass_state == BYPASS_RD) && (bypass.rd == rd));
    WordFL val= (  ((bypass.bypass_state == BYPASS_RD_RDVAL) && (bypass.rd == rd))
 		? bypass.rd_val
@@ -571,7 +572,7 @@ typedef struct {
    Dii_Id instr_seq;
 `endif
    Op_Stage2  op_stage2;
-   RegName    rd;
+   RegAddr    rd;
    Addr       addr;     // Branch, jump: newPC
                         // Mem ops and AMOs: mem addr
 
@@ -756,7 +757,7 @@ typedef struct {
    Priv_Mode priv;
 
    Bool      rd_valid;
-   RegName   rd;
+   RegAddr   rd;
    Pipeline_Val#(CapReg) rd_val;
 
 `ifdef RVFI

--- a/src_Core/CPU/CPU_Stage1.bsv
+++ b/src_Core/CPU/CPU_Stage1.bsv
@@ -124,7 +124,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    let funct3         = decoded_instr.funct3;
 
    // Register rs1 read and bypass
-   let rs1 = get_GPR_reg_addr(decoded_instr.rs1);
+   let rs1 = get_GPR_addr(decoded_instr.rs1);
    let rs1_val = gpr_regfile.read_rs1 (rs1);
    match { .busy1a, .rs1a } = fn_gpr_bypass (bypass_from_stage3, rs1, rs1_val);
    match { .busy1b, .rs1b } = fn_gpr_bypass (bypass_from_stage2, rs1, rs1a);
@@ -136,7 +136,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `endif
 
    // Register rs2 read and bypass
-   let rs2 = get_GPR_reg_addr(decoded_instr.rs2);
+   let rs2 = get_GPR_addr(decoded_instr.rs2);
    let rs2_val = gpr_regfile.read_rs2 (rs2);
    match { .busy2a, .rs2a } = fn_gpr_bypass (bypass_from_stage3, rs2, rs2_val);
    match { .busy2b, .rs2b } = fn_gpr_bypass (bypass_from_stage2, rs2, rs2a);
@@ -163,7 +163,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    WordFL frs2_val_bypassed = frs2b;
 
    // FP Register rs3 read and bypass
-   let rs3 = get_GPR_reg_addr(decoded_instr.rs3);
+   let rs3 = get_GPR_addr(decoded_instr.rs3);
    let frs3_val = fpr_regfile.read_rs3 (rs3);
    match { .fbusy3a, .frs3a } = fn_fpr_bypass (fbypass_from_stage3, rs3, frs3_val);
    match { .fbusy3b, .frs3b } = fn_fpr_bypass (fbypass_from_stage2, rs3, frs3a);
@@ -268,7 +268,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
                                                instr_seq     : rg_stage_input.instr_seq,
 `endif
 					       op_stage2     : alu_outputs.op_stage2,
-					       rd            : get_GPR_reg_addr(alu_outputs.rd),
+					       rd            : get_GPR_addr(alu_outputs.rd),
 					       addr          : alu_outputs.addr,
                                                mem_width_code: alu_outputs.mem_width_code,
                                                mem_unsigned  : alu_outputs.mem_unsigned,

--- a/src_Core/CPU/CPU_Stage1.bsv
+++ b/src_Core/CPU/CPU_Stage1.bsv
@@ -124,7 +124,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    let funct3         = decoded_instr.funct3;
 
    // Register rs1 read and bypass
-   let rs1 = decoded_instr.rs1;
+   let rs1 = getGPRAddr(decoded_instr.rs1,0);
    let rs1_val = gpr_regfile.read_rs1 (rs1);
    match { .busy1a, .rs1a } = fn_gpr_bypass (bypass_from_stage3, rs1, rs1_val);
    match { .busy1b, .rs1b } = fn_gpr_bypass (bypass_from_stage2, rs1, rs1a);
@@ -136,7 +136,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `endif
 
    // Register rs2 read and bypass
-   let rs2 = decoded_instr.rs2;
+   let rs2 = getGPRAddr(decoded_instr.rs2,0);
    let rs2_val = gpr_regfile.read_rs2 (rs2);
    match { .busy2a, .rs2a } = fn_gpr_bypass (bypass_from_stage3, rs2, rs2_val);
    match { .busy2b, .rs2b } = fn_gpr_bypass (bypass_from_stage2, rs2, rs2a);
@@ -163,7 +163,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    WordFL frs2_val_bypassed = frs2b;
 
    // FP Register rs3 read and bypass
-   let rs3 = decoded_instr.rs3;
+   let rs3 = getGPRAddr(decoded_instr.rs3, 0);
    let frs3_val = fpr_regfile.read_rs3 (rs3);
    match { .fbusy3a, .frs3a } = fn_fpr_bypass (fbypass_from_stage3, rs3, frs3_val);
    match { .fbusy3b, .frs3b } = fn_fpr_bypass (fbypass_from_stage2, rs3, frs3a);
@@ -189,8 +189,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `ifdef ISA_CHERI
 				cap_rs1_val    : rs1_val_bypassed,
 				cap_rs2_val    : rs2_val_bypassed,
-				rs1_idx        : rs1,
-				rs2_idx        : rs2,
+				rs1_idx        : addrToName(rs1),
+				rs2_idx        : addrToName(rs2),
 				rs1_val        : getAddr(rs1_val_bypassed),
 				rs2_val        : getAddr(rs2_val_bypassed),
 `else
@@ -231,8 +231,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    CapMem cap_val2 = cast(tmp_val2);
    let info_RVFI = Data_RVFI_Stage1 {
                        instr:          rg_stage_input.instr_or_instr_C,
-                       rs1_addr:       rs1,
-                       rs2_addr:       rs2,
+                       rs1_addr:       addrToName(rs1),
+                       rs2_addr:       addrToName(rs2),
 `ifdef ISA_CHERI
                        rs1_data:       getAddr(rs1_val_bypassed),
                        rs2_data:       getAddr(rs2_val_bypassed),
@@ -268,7 +268,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
                                                instr_seq     : rg_stage_input.instr_seq,
 `endif
 					       op_stage2     : alu_outputs.op_stage2,
-					       rd            : alu_outputs.rd,
+					       rd            : getGPRAddr(alu_outputs.rd,0),
 					       addr          : alu_outputs.addr,
                                                mem_width_code: alu_outputs.mem_width_code,
                                                mem_unsigned  : alu_outputs.mem_unsigned,

--- a/src_Core/CPU/CPU_Stage1.bsv
+++ b/src_Core/CPU/CPU_Stage1.bsv
@@ -124,7 +124,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    let funct3         = decoded_instr.funct3;
 
    // Register rs1 read and bypass
-   let rs1 = getPhysRegAddr(decoded_instr.rs1,0);
+   let rs1 = get_GPR_reg_addr(decoded_instr.rs1);
    let rs1_val = gpr_regfile.read_rs1 (rs1);
    match { .busy1a, .rs1a } = fn_gpr_bypass (bypass_from_stage3, rs1, rs1_val);
    match { .busy1b, .rs1b } = fn_gpr_bypass (bypass_from_stage2, rs1, rs1a);
@@ -136,7 +136,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `endif
 
    // Register rs2 read and bypass
-   let rs2 = getPhysRegAddr(decoded_instr.rs2,0);
+   let rs2 = get_GPR_reg_addr(decoded_instr.rs2);
    let rs2_val = gpr_regfile.read_rs2 (rs2);
    match { .busy2a, .rs2a } = fn_gpr_bypass (bypass_from_stage3, rs2, rs2_val);
    match { .busy2b, .rs2b } = fn_gpr_bypass (bypass_from_stage2, rs2, rs2a);
@@ -163,7 +163,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    WordFL frs2_val_bypassed = frs2b;
 
    // FP Register rs3 read and bypass
-   let rs3 = getPhysRegAddr(decoded_instr.rs3, 0);
+   let rs3 = get_GPR_reg_addr(decoded_instr.rs3);
    let frs3_val = fpr_regfile.read_rs3 (rs3);
    match { .fbusy3a, .frs3a } = fn_fpr_bypass (fbypass_from_stage3, rs3, frs3_val);
    match { .fbusy3b, .frs3b } = fn_fpr_bypass (fbypass_from_stage2, rs3, frs3a);
@@ -189,8 +189,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `ifdef ISA_CHERI
 				cap_rs1_val    : rs1_val_bypassed,
 				cap_rs2_val    : rs2_val_bypassed,
-				rs1_idx        : regAddrToName(rs1),
-				rs2_idx        : regAddrToName(rs2),
+				rs1_idx        : reg_addr_to_name(rs1),
+				rs2_idx        : reg_addr_to_name(rs2),
 				rs1_val        : getAddr(rs1_val_bypassed),
 				rs2_val        : getAddr(rs2_val_bypassed),
 `else
@@ -231,8 +231,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    CapMem cap_val2 = cast(tmp_val2);
    let info_RVFI = Data_RVFI_Stage1 {
                        instr:          rg_stage_input.instr_or_instr_C,
-                       rs1_addr:       regAddrToName(rs1),
-                       rs2_addr:       regAddrToName(rs2),
+                       rs1_addr:       reg_addr_to_name(rs1),
+                       rs2_addr:       reg_addr_to_name(rs2),
 `ifdef ISA_CHERI
                        rs1_data:       getAddr(rs1_val_bypassed),
                        rs2_data:       getAddr(rs2_val_bypassed),
@@ -268,7 +268,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
                                                instr_seq     : rg_stage_input.instr_seq,
 `endif
 					       op_stage2     : alu_outputs.op_stage2,
-					       rd            : getPhysRegAddr(alu_outputs.rd,0),
+					       rd            : get_GPR_reg_addr(alu_outputs.rd),
 					       addr          : alu_outputs.addr,
                                                mem_width_code: alu_outputs.mem_width_code,
                                                mem_unsigned  : alu_outputs.mem_unsigned,

--- a/src_Core/CPU/CPU_Stage1.bsv
+++ b/src_Core/CPU/CPU_Stage1.bsv
@@ -124,7 +124,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    let funct3         = decoded_instr.funct3;
 
    // Register rs1 read and bypass
-   let rs1 = getGPRAddr(decoded_instr.rs1,0);
+   let rs1 = getPhysRegAddr(decoded_instr.rs1,0);
    let rs1_val = gpr_regfile.read_rs1 (rs1);
    match { .busy1a, .rs1a } = fn_gpr_bypass (bypass_from_stage3, rs1, rs1_val);
    match { .busy1b, .rs1b } = fn_gpr_bypass (bypass_from_stage2, rs1, rs1a);
@@ -136,7 +136,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `endif
 
    // Register rs2 read and bypass
-   let rs2 = getGPRAddr(decoded_instr.rs2,0);
+   let rs2 = getPhysRegAddr(decoded_instr.rs2,0);
    let rs2_val = gpr_regfile.read_rs2 (rs2);
    match { .busy2a, .rs2a } = fn_gpr_bypass (bypass_from_stage3, rs2, rs2_val);
    match { .busy2b, .rs2b } = fn_gpr_bypass (bypass_from_stage2, rs2, rs2a);
@@ -163,7 +163,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    WordFL frs2_val_bypassed = frs2b;
 
    // FP Register rs3 read and bypass
-   let rs3 = getGPRAddr(decoded_instr.rs3, 0);
+   let rs3 = getPhysRegAddr(decoded_instr.rs3, 0);
    let frs3_val = fpr_regfile.read_rs3 (rs3);
    match { .fbusy3a, .frs3a } = fn_fpr_bypass (fbypass_from_stage3, rs3, frs3_val);
    match { .fbusy3b, .frs3b } = fn_fpr_bypass (fbypass_from_stage2, rs3, frs3a);
@@ -189,8 +189,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
 `ifdef ISA_CHERI
 				cap_rs1_val    : rs1_val_bypassed,
 				cap_rs2_val    : rs2_val_bypassed,
-				rs1_idx        : addrToName(rs1),
-				rs2_idx        : addrToName(rs2),
+				rs1_idx        : regAddrToName(rs1),
+				rs2_idx        : regAddrToName(rs2),
 				rs1_val        : getAddr(rs1_val_bypassed),
 				rs2_val        : getAddr(rs2_val_bypassed),
 `else
@@ -231,8 +231,8 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
    CapMem cap_val2 = cast(tmp_val2);
    let info_RVFI = Data_RVFI_Stage1 {
                        instr:          rg_stage_input.instr_or_instr_C,
-                       rs1_addr:       addrToName(rs1),
-                       rs2_addr:       addrToName(rs2),
+                       rs1_addr:       regAddrToName(rs1),
+                       rs2_addr:       regAddrToName(rs2),
 `ifdef ISA_CHERI
                        rs1_data:       getAddr(rs1_val_bypassed),
                        rs2_data:       getAddr(rs2_val_bypassed),
@@ -268,7 +268,7 @@ module mkCPU_Stage1 #(Bit #(4)         verbosity,
                                                instr_seq     : rg_stage_input.instr_seq,
 `endif
 					       op_stage2     : alu_outputs.op_stage2,
-					       rd            : getGPRAddr(alu_outputs.rd,0),
+					       rd            : getPhysRegAddr(alu_outputs.rd,0),
 					       addr          : alu_outputs.addr,
                                                mem_width_code: alu_outputs.mem_width_code,
                                                mem_unsigned  : alu_outputs.mem_unsigned,

--- a/src_Core/RegFiles/FPR_RegFile.bsv
+++ b/src_Core/RegFiles/FPR_RegFile.bsv
@@ -19,6 +19,7 @@ import RegFile      :: *;
 import FIFOF        :: *;
 import GetPut       :: *;
 import ClientServer :: *;
+import GPR_RegFile :: *;
 
 
 // BSV additional libs
@@ -38,17 +39,17 @@ interface FPR_RegFile_IFC;
 
    // FPR read
    (* always_ready *)
-   method WordFL read_rs1 (RegName rs1);
+   method WordFL read_rs1 (RegAddr rs1);
    (* always_ready *)
-   method WordFL read_rs1_port2 (RegName rs1);    // For debugger access only
+   method WordFL read_rs1_port2 (RegAddr rs1);    // For debugger access only
    (* always_ready *)
-   method WordFL read_rs2 (RegName rs2);
+   method WordFL read_rs2 (RegAddr rs2);
    (* always_ready *)
-   method WordFL read_rs3 (RegName rs3);
+   method WordFL read_rs3 (RegAddr rs3);
 
    // FPR write
    (* always_ready *)
-   method Action write_rd (RegName rd, WordFL rd_val);
+   method Action write_rd (RegAddr rd, WordFL rd_val);
 
 endinterface
 
@@ -123,25 +124,50 @@ module mkFPR_RegFile (FPR_RegFile_IFC);
    endinterface
 
    // FPR read
-   method WordFL read_rs1 (RegName rs1);
+   /*method WordFL read_rs1 (RegName rs1);
       return (regfile.sub (rs1));
+   endmethod*/
+   //Compatibility
+   method WordFL read_rs1 (RegAddr rs1);
+      RegName rn = unpack(truncate(pack(rs1)));
+      return (regfile.sub (rn));
    endmethod
 
    // FPR read
-   method WordFL read_rs1_port2 (RegName rs1);        // For debugger access only
+   /*method WordFL read_rs1_port2 (RegName rs1);        // For debugger access only
       return (regfile.sub (rs1));
+   endmethod*/
+   //Compatibility
+   method WordFL read_rs1_port2 (RegAddr rs1);
+      RegName rn = unpack(truncate(pack(rs1)));
+      return (regfile.sub (rn));
    endmethod
 
-   method WordFL read_rs2 (RegName rs2);
+   /*method WordFL read_rs2 (RegName rs2);
       return (regfile.sub (rs2));
+   endmethod*/
+   //Compatibility
+   method WordFL read_rs2 (RegAddr rs2);
+      RegName rn = unpack(truncate(pack(rs2)));
+      return (regfile.sub (rn));
    endmethod
 
-   method WordFL read_rs3 (RegName rs3);
+   /*method WordFL read_rs3 (RegName rs3);
       return (regfile.sub (rs3));
+   endmethod*/
+   //Compatibility
+   method WordFL read_rs3 (RegAddr rs3);
+      RegName rn = unpack(truncate(pack(rs3)));
+      return (regfile.sub (rn));
    endmethod
 
    // FPR write
-   method Action write_rd (RegName rd, WordFL rd_val);
+   /*method Action write_rd (RegName rd, WordFL rd_val);
+      regfile.upd (rd, rd_val);
+   endmethod*/
+   //Compatibility
+   method Action write_rd (RegAddr rd, WordFL rd_val);
+      RegName rd = unpack(truncate(pack(rd)));
       regfile.upd (rd, rd_val);
    endmethod
 

--- a/src_Core/RegFiles/FPR_RegFile.bsv
+++ b/src_Core/RegFiles/FPR_RegFile.bsv
@@ -124,9 +124,6 @@ module mkFPR_RegFile (FPR_RegFile_IFC);
    endinterface
 
    // FPR read
-   /*method WordFL read_rs1 (RegName rs1);
-      return (regfile.sub (rs1));
-   endmethod*/
    //Compatibility
    method WordFL read_rs1 (RegAddr rs1);
       RegName rn = unpack(truncate(pack(rs1)));
@@ -134,27 +131,18 @@ module mkFPR_RegFile (FPR_RegFile_IFC);
    endmethod
 
    // FPR read
-   /*method WordFL read_rs1_port2 (RegName rs1);        // For debugger access only
-      return (regfile.sub (rs1));
-   endmethod*/
-   //Compatibility
+   //Compatibility, todo: move into GPR
    method WordFL read_rs1_port2 (RegAddr rs1);
       RegName rn = unpack(truncate(pack(rs1)));
       return (regfile.sub (rn));
    endmethod
 
-   /*method WordFL read_rs2 (RegName rs2);
-      return (regfile.sub (rs2));
-   endmethod*/
    //Compatibility
    method WordFL read_rs2 (RegAddr rs2);
       RegName rn = unpack(truncate(pack(rs2)));
       return (regfile.sub (rn));
    endmethod
 
-   /*method WordFL read_rs3 (RegName rs3);
-      return (regfile.sub (rs3));
-   endmethod*/
    //Compatibility
    method WordFL read_rs3 (RegAddr rs3);
       RegName rn = unpack(truncate(pack(rs3)));
@@ -162,9 +150,6 @@ module mkFPR_RegFile (FPR_RegFile_IFC);
    endmethod
 
    // FPR write
-   /*method Action write_rd (RegName rd, WordFL rd_val);
-      regfile.upd (rd, rd_val);
-   endmethod*/
    //Compatibility
    method Action write_rd (RegAddr rd, WordFL rd_val);
       RegName rd = unpack(truncate(pack(rd)));

--- a/src_Core/RegFiles/GPR_RegFile.bsv
+++ b/src_Core/RegFiles/GPR_RegFile.bsv
@@ -20,7 +20,7 @@ package GPR_RegFile;
 // ================================================================
 // Exports
 
-export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, getPhysRegAddr, regAddrToName;
+export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, get_GPR_reg_addr, get_vec_reg_addr, reg_addr_to_name;
 
 // ================================================================
 // BSV library imports
@@ -46,7 +46,7 @@ import CHERICC_Fat :: *;
 
 // ================================================================
 
-`define REG_SIZE 7
+`define REG_ADDR_SIZE 6 
 `ifdef ISA_CHERI
 `define INTERNAL_REG_TYPE CapReg
 `define EXTERNAL_REG_TYPE_OUT CapPipe
@@ -106,22 +106,20 @@ endinterface
 // Major states of mkGPR_RegFile module
 
 typedef enum { RF_RESET_START, RF_RESETTING, RF_RUNNING } RF_State deriving (Eq, Bits, FShow);
-typedef Bit#(`REG_SIZE) RegAddr;
+typedef Bit#(`REG_ADDR_SIZE) RegAddr;
 
 
 // ================================================================
 // Address conversion
 // Prefix=0 => Using standard integer GPR
-function RegAddr getPhysRegAddr(RegName name, Bit#(m) prefix)
-   provisos(Add#(5, m, `REG_SIZE));
-   Bit#(`REG_SIZE) addr = {name, prefix};
+function RegAddr get_GPR_reg_addr(RegName name);
+   Bit#(`REG_ADDR_SIZE) addr = zeroExtend(name);
    return addr;
 endfunction
 
-function Bit#(5) regAddrToName(RegAddr addr);
+function Bit#(5) reg_addr_to_name(RegAddr addr);
    return truncate(pack(addr));
 endfunction
-
 
 // ================================================================
 

--- a/src_Core/RegFiles/GPR_RegFile.bsv
+++ b/src_Core/RegFiles/GPR_RegFile.bsv
@@ -111,7 +111,6 @@ typedef Bit#(`REG_ADDR_SIZE) RegAddr;
 
 // ================================================================
 // Address conversion
-// Prefix=0 => Using standard integer GPR
 function RegAddr get_GPR_addr(RegName name);
    Bit#(`REG_ADDR_SIZE) addr = zeroExtend(name);
    return addr;

--- a/src_Core/RegFiles/GPR_RegFile.bsv
+++ b/src_Core/RegFiles/GPR_RegFile.bsv
@@ -20,7 +20,7 @@ package GPR_RegFile;
 // ================================================================
 // Exports
 
-export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, getGPRAddr, addrToName;
+export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, getPhysRegAddr, regAddrToName;
 
 // ================================================================
 // BSV library imports
@@ -112,13 +112,13 @@ typedef Bit#(`REG_SIZE) RegAddr;
 // ================================================================
 // Address conversion
 // Prefix=0 => Using standard integer GPR
-function RegAddr getGPRAddr(RegName name, Bit#(m) prefix)
+function RegAddr getPhysRegAddr(RegName name, Bit#(m) prefix)
    provisos(Add#(5, m, `REG_SIZE));
    Bit#(`REG_SIZE) addr = {name, prefix};
    return addr;
 endfunction
 
-function Bit#(5) addrToName(RegAddr addr);
+function Bit#(5) regAddrToName(RegAddr addr);
    return truncate(pack(addr));
 endfunction
 

--- a/src_Core/RegFiles/GPR_RegFile.bsv
+++ b/src_Core/RegFiles/GPR_RegFile.bsv
@@ -20,7 +20,7 @@ package GPR_RegFile;
 // ================================================================
 // Exports
 
-export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, get_GPR_reg_addr, get_vec_reg_addr, reg_addr_to_name;
+export GPR_RegFile_IFC (..), mkGPR_RegFile, RegAddr, get_GPR_addr, reg_addr_to_name;
 
 // ================================================================
 // BSV library imports
@@ -112,7 +112,7 @@ typedef Bit#(`REG_ADDR_SIZE) RegAddr;
 // ================================================================
 // Address conversion
 // Prefix=0 => Using standard integer GPR
-function RegAddr get_GPR_reg_addr(RegName name);
+function RegAddr get_GPR_addr(RegName name);
    Bit#(`REG_ADDR_SIZE) addr = zeroExtend(name);
    return addr;
 endfunction

--- a/src_Verifier/Verifier.bsv
+++ b/src_Verifier/Verifier.bsv
@@ -71,9 +71,9 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoCondensed(
         rvfi_rs1_addr:  s1.rs1_addr,
         rvfi_rs2_addr:  s1.rs2_addr,
 `ifdef ISA_F
-        rvfi_rd_addr:   regAddrToName(data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0)),
+        rvfi_rd_addr:   reg_addr_to_name(data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0)),
 `else
-        rvfi_rd_addr:   regAddrToName(data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
+        rvfi_rd_addr:   reg_addr_to_name(data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
 `endif
         rvfi_rs1_data:  s1.rs1_data,
         rvfi_rs2_data:  s1.rs2_data,
@@ -138,7 +138,7 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoS1 (
         rvfi_mem_addr:  s1.mem_addr,
         // Although we know what rd *would* be, the fact that we're using this function
         // means we can't have actually written to it.
-        rvfi_rd_addr:   regAddrToName(data_s1_s2.rd),
+        rvfi_rd_addr:   reg_addr_to_name(data_s1_s2.rd),
         rvfi_rd_wdata:  fromMaybe(0, rwd),
         rvfi_mem_rmask: 0,
         rvfi_mem_wmask: 0,

--- a/src_Verifier/Verifier.bsv
+++ b/src_Verifier/Verifier.bsv
@@ -28,6 +28,7 @@
  */
 
 package Verifier;
+import GPR_RegFile      :: *;
 
 
 `ifdef INCLUDE_TANDEM_VERIF
@@ -70,9 +71,9 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoCondensed(
         rvfi_rs1_addr:  s1.rs1_addr,
         rvfi_rs2_addr:  s1.rs2_addr,
 `ifdef ISA_F
-        rvfi_rd_addr:   data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
+        rvfi_rd_addr:   addrToName(data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0)),
 `else
-        rvfi_rd_addr:   data_s2_s3.rd_valid ? data_s2_s3.rd : 0,
+        rvfi_rd_addr:   addrToName(data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
 `endif
         rvfi_rs1_data:  s1.rs1_data,
         rvfi_rs2_data:  s1.rs2_data,
@@ -137,7 +138,7 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoS1 (
         rvfi_mem_addr:  s1.mem_addr,
         // Although we know what rd *would* be, the fact that we're using this function
         // means we can't have actually written to it.
-        rvfi_rd_addr:   data_s1_s2.rd,
+        rvfi_rd_addr:   addrToName(data_s1_s2.rd),
         rvfi_rd_wdata:  fromMaybe(0, rwd),
         rvfi_mem_rmask: 0,
         rvfi_mem_wmask: 0,

--- a/src_Verifier/Verifier.bsv
+++ b/src_Verifier/Verifier.bsv
@@ -71,9 +71,9 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoCondensed(
         rvfi_rs1_addr:  s1.rs1_addr,
         rvfi_rs2_addr:  s1.rs2_addr,
 `ifdef ISA_F
-        rvfi_rd_addr:   addrToName(data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0)),
+        rvfi_rd_addr:   regAddrToName(data_s2_s3.rd_in_fpr ? 0 : (data_s2_s3.rd_valid ? data_s2_s3.rd : 0)),
 `else
-        rvfi_rd_addr:   addrToName(data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
+        rvfi_rd_addr:   regAddrToName(data_s2_s3.rd_valid ? data_s2_s3.rd : 0),
 `endif
         rvfi_rs1_data:  s1.rs1_data,
         rvfi_rs2_data:  s1.rs2_data,
@@ -138,7 +138,7 @@ function RVFI_DII_Execution #(XLEN,MEMWIDTH) getRVFIInfoS1 (
         rvfi_mem_addr:  s1.mem_addr,
         // Although we know what rd *would* be, the fact that we're using this function
         // means we can't have actually written to it.
-        rvfi_rd_addr:   addrToName(data_s1_s2.rd),
+        rvfi_rd_addr:   regAddrToName(data_s1_s2.rd),
         rvfi_rd_wdata:  fromMaybe(0, rwd),
         rvfi_mem_rmask: 0,
         rvfi_mem_wmask: 0,


### PR DESCRIPTION
At the moment the GPR register file uses RegName for addressing the register file. This makes extending the register file a hassle. I've decoupled the register file from the RegName type by introducing a new type, RegAddr, which can easily be changed to allow for increasing the register file size.